### PR TITLE
Use upstream testify assert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,17 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)
+
+require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
-	github.com/gin-contrib/gzip v1.2.3 // indirect
+	github.com/gin-contrib/gzip v1.2.3
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -34,6 +39,7 @@ require (
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/testify v1.11.1
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,7 +43,6 @@ github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzh
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/psproxy_test.go
+++ b/psproxy_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"presto-shadow-proxy/presto"
 )
 
@@ -33,16 +34,11 @@ func TestHandlePrestoStatementWithoutNextURI(t *testing.T) {
 	}
 
 	prodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method for production server: %s", r.Method)
-		}
-		if r.URL.Path != "/v1/statement" {
-			t.Fatalf("unexpected path for production server: %s", r.URL.Path)
-		}
+		assert.Equal(t, http.MethodPost, r.Method, "unexpected method for production server")
+		assert.Equal(t, "/v1/statement", r.URL.Path, "unexpected path for production server")
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(prodResponse); err != nil {
-			t.Fatalf("failed to encode production response: %v", err)
-		}
+		err := json.NewEncoder(w).Encode(prodResponse)
+		assert.NoError(t, err, "failed to encode production response")
 	}))
 	defer prodServer.Close()
 
@@ -55,32 +51,21 @@ func TestHandlePrestoStatementWithoutNextURI(t *testing.T) {
 	}
 
 	shadowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Fatalf("unexpected method for shadow server: %s", r.Method)
-		}
-		if !strings.HasPrefix(r.URL.Path, "/v1/statement/") {
-			t.Fatalf("unexpected path for shadow server: %s", r.URL.Path)
-		}
-		if slug := r.URL.Query().Get("slug"); slug != "" {
-			t.Fatalf("expected empty slug, got %q", slug)
-		}
+		assert.Equal(t, http.MethodPut, r.Method, "unexpected method for shadow server")
+		assert.True(t, strings.HasPrefix(r.URL.Path, "/v1/statement/"), "unexpected path for shadow server: %s", r.URL.Path)
+		assert.Empty(t, r.URL.Query().Get("slug"), "expected empty slug")
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(shadowResponse); err != nil {
-			t.Fatalf("failed to encode shadow response: %v", err)
-		}
+		err := json.NewEncoder(w).Encode(shadowResponse)
+		assert.NoError(t, err, "failed to encode shadow response")
 		shadowHit <- struct{}{}
 	}))
 	defer shadowServer.Close()
 
 	var err error
 	prodClient, err = presto.NewClient(prodServer.URL, false)
-	if err != nil {
-		t.Fatalf("failed to create production client: %v", err)
-	}
+	assert.NoError(t, err, "failed to create production client")
 	shadowClient, err = presto.NewClient(shadowServer.URL, false)
-	if err != nil {
-		t.Fatalf("failed to create shadow client: %v", err)
-	}
+	assert.NoError(t, err, "failed to create shadow client")
 
 	config = &ShadowProxyConfig{
 		ProdAddress:   prodServer.URL,
@@ -97,25 +82,65 @@ func TestHandlePrestoStatementWithoutNextURI(t *testing.T) {
 
 	handlePrestoStatement(ctx)
 
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("unexpected status code: got %d, want %d", recorder.Code, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, recorder.Code, "unexpected status code")
 
 	var got presto.QueryResults
-	if err := json.Unmarshal(recorder.Body.Bytes(), &got); err != nil {
-		t.Fatalf("failed to decode response body: %v", err)
-	}
+	err = json.Unmarshal(recorder.Body.Bytes(), &got)
+	assert.NoError(t, err, "failed to decode response body")
 
-	if got.Id != prodResponse.Id {
-		t.Fatalf("unexpected query id: got %s, want %s", got.Id, prodResponse.Id)
-	}
-	if got.NextUri != nil {
-		t.Fatalf("expected nil nextUri, got %v", *got.NextUri)
-	}
+	assert.Equal(t, prodResponse.Id, got.Id, "unexpected query id")
+	assert.Nil(t, got.NextUri, "expected nil nextUri")
 
 	select {
 	case <-shadowHit:
 	case <-time.After(time.Second):
-		t.Fatal("shadow query was not executed")
+		assert.Fail(t, "shadow query was not executed")
 	}
+}
+
+func TestPatchConfigInvalidUpdateDoesNotMutateCurrentConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	origConfig := config
+	origProdClient := prodClient
+	origShadowClient := shadowClient
+	origProxy := proxy
+	defer func() {
+		config = origConfig
+		prodClient = origProdClient
+		shadowClient = origShadowClient
+		proxy = origProxy
+	}()
+
+	config = &ShadowProxyConfig{
+		ProdAddress:   "http://prod.example.com",
+		ShadowAddress: "http://shadow.example.com",
+		ProxyPort:     8080,
+	}
+	err := config.Apply()
+	assert.NoError(t, err, "failed to apply initial config")
+
+	initialConfigPtr := config
+	initialConfigValue := *config
+	initialProdClient := prodClient
+	initialShadowClient := shadowClient
+	initialProxy := proxy
+
+	engine := gin.New()
+	engine.PATCH("/proxy/config", handleConfigPatch)
+
+	body := `{"ProdAddress":""}`
+	req := httptest.NewRequest(http.MethodPatch, "/proxy/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code, "unexpected status code")
+
+	assert.Same(t, initialConfigPtr, config, "config pointer changed on invalid update")
+	assert.Equal(t, initialConfigValue, *config, "config values changed on invalid update")
+	assert.Same(t, initialProdClient, prodClient, "prodClient changed on invalid update")
+	assert.Same(t, initialShadowClient, shadowClient, "shadowClient changed on invalid update")
+	assert.Same(t, initialProxy, proxy, "proxy changed on invalid update")
 }


### PR DESCRIPTION
## Summary
- depend on the upstream github.com/stretchr/testify module instead of a vendored assert copy
- update the psproxy tests to call the testify helpers with the testing object they operate on

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df521e91f4832eaefb9fb49bfa74b3